### PR TITLE
Allow empty <sum>

### DIFF
--- a/src/Data/PseudoBoolean/Attoparsec.hs
+++ b/src/Data/PseudoBoolean/Attoparsec.hs
@@ -126,7 +126,7 @@ constraint = do
 
 -- <sum>::= <weightedterm> | <weightedterm> <sum>
 sum :: Parser Sum
-sum = many1 weightedterm
+sum = many' weightedterm -- we relax the grammer to allow empty sum
 
 -- <weightedterm>::= <integer> <oneOrMoreSpace> <term> <oneOrMoreSpace>
 weightedterm :: Parser WeightedTerm

--- a/src/Data/PseudoBoolean/Megaparsec.hs
+++ b/src/Data/PseudoBoolean/Megaparsec.hs
@@ -184,7 +184,7 @@ constraint = do
 
 -- <sum>::= <weightedterm> | <weightedterm> <sum>
 sum :: C e s m => m Sum
-sum = some weightedterm
+sum = many weightedterm -- we relax the grammer to allow empty sum
 
 -- <weightedterm>::= <integer> <oneOrMoreSpace> <term> <oneOrMoreSpace>
 weightedterm :: C e s m => m WeightedTerm

--- a/src/Data/PseudoBoolean/Parsec.hs
+++ b/src/Data/PseudoBoolean/Parsec.hs
@@ -126,7 +126,7 @@ constraint = do
 
 -- <sum>::= <weightedterm> | <weightedterm> <sum>
 sum :: Stream s m Char => ParsecT s u m Sum
-sum = many1 weightedterm
+sum = many weightedterm -- we relax the grammer to allow empty sum
 
 -- <weightedterm>::= <integer> <oneOrMoreSpace> <term> <oneOrMoreSpace>
 weightedterm :: Stream s m Char => ParsecT s u m WeightedTerm

--- a/test/TestPBFile.hs
+++ b/test/TestPBFile.hs
@@ -41,6 +41,10 @@ case_normalized_mds_50_10_4 = checkOPBFile "test/samples/normalized-mds_50_10_4.
 case_normalized_opt_market_split_4_30_2 = checkOPBFile "test/samples/normalized-opt-market-split_4_30_2.opb"
 case_pigeonhole_5_4 = checkOPBFile "test/samples/pigeonhole_5_4.opb"
 
+case_invalid_obj_empty_sum = checkOPBFile "test/samples/invalid-obj-empty-sum.opb"
+case_invalid_lhs_empty_sum = checkOPBFile "test/samples/invalid-lhs-empty-sum.opb"
+case_invalid_lhs_empty_sum_wbo = checkWBOFile "test/samples/invalid-lhs-empty-sum.wbo"
+
 case_trailing_junk = do
   isError (parseOPBString "" trailingJunk) @?= True
   isError (M.parseOPBString "" trailingJunk) @?= True

--- a/test/samples/invalid-lhs-empty-sum.opb
+++ b/test/samples/invalid-lhs-empty-sum.opb
@@ -1,0 +1,4 @@
+* #variable= 0 #constraint= 1
+* This is invalid according to the grammer of http://www.cril.univ-artois.fr/PB11/format.pdf ,
+* but we relax the grammar to allow it.
+>= 0;

--- a/test/samples/invalid-lhs-empty-sum.wbo
+++ b/test/samples/invalid-lhs-empty-sum.wbo
@@ -1,0 +1,6 @@
+* #variable= 0 #constraint= 2 #soft= 1 mincost= 1 maxcost= 1 sumcost= 1
+* This is invalid according to the grammer of http://www.cril.univ-artois.fr/PB11/format.pdf ,
+* but we relax the grammar to allow it.
+soft: ;
+[1] >= 1;
+>= 0;

--- a/test/samples/invalid-obj-empty-sum.opb
+++ b/test/samples/invalid-obj-empty-sum.opb
@@ -1,0 +1,4 @@
+* #variable= 0 #constraint= 0
+* This is invalid according to the grammer of http://www.cril.univ-artois.fr/PB11/format.pdf ,
+* but we relax the grammar to allow it.
+min: ;


### PR DESCRIPTION
http://www.cril.univ-artois.fr/PB11/format.pdf defines `<sum>` as a non-empty sequence of `<weightedterm>`, but this PR relaxes the grammar to allow empty sequence as well.

This is because we defined `Sum` type as `[WeightedTerm]` instead of `NonEmpty WeightedTerm` and it is possible to accidentally produce files that contain empty `<sum>`. We will consider preventing the generation of such files separately.

Refs #4