### PR TITLE
Fix to generate correct hint

### DIFF
--- a/src/Data/PseudoBoolean/Builder.hs
+++ b/src/Data/PseudoBoolean/Builder.hs
@@ -72,7 +72,7 @@ wboBuilder wbo = size <> part1 <> part2
     size = fromString (printf "* #variable= %d #constraint= %d" nv nc)
          <> (if np >= 1 then fromString (printf " #product= %d sizeproduct= %d" np sp) else mempty)
          <> fromString (printf " #soft= %d" (wboNumSoft wbo))
-         <> fromString (printf " #mincost= %d #maxcost= %d #sumcost= %d" mincost maxcost sumcost)
+         <> fromString (printf " mincost= %d maxcost= %d sumcost= %d" mincost maxcost sumcost)
          <> fromString "\n"
     part1 = 
       case wboTopCost wbo of

--- a/src/Data/PseudoBoolean/ByteStringBuilder.hs
+++ b/src/Data/PseudoBoolean/ByteStringBuilder.hs
@@ -78,9 +78,9 @@ wboBuilder wbo = size <> part1 <> part2
     size = string7 "* #variable= " <> intDec nv <> string7 " #constraint= " <> intDec nc
          <> (if np >= 1 then string7 " #product= " <> intDec np <> string7 " sizeproduct= " <> intDec sp else mempty)
          <> string7 " #soft= " <> intDec (wboNumSoft wbo)
-         <> string7 " #mincost= " <> integerDec mincost
-         <> string7 " #maxcost= " <> integerDec maxcost
-         <> string7 " #sumcost= " <> integerDec sumcost
+         <> string7 " mincost= " <> integerDec mincost
+         <> string7 " maxcost= " <> integerDec maxcost
+         <> string7 " sumcost= " <> integerDec sumcost
          <> char7 '\n'
     part1 = 
       case wboTopCost wbo of


### PR DESCRIPTION
`mincost=`, `maxcost=`, and `sumcost=` do not need `#`-prefix